### PR TITLE
Stop modifying options argument

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -15,14 +15,14 @@ const re = {
  * @typicalname wordwrap
  */
 class WordWrap {
-  constructor (text, options) {
-    options = options || {}
+  constructor (text, options = {}) {
     if (!t.isDefined(text)) text = ''
 
     this._lines = String(text).split(/\r\n|\n/g)
-    this.options = options
-    this.options.width = options.width === undefined ? 30 : options.width
-    this.options.eol = options.eol || '\n'
+    this.options = Object.assign({
+        eol: '\n',
+        width: 30
+    }, options);
   }
 
   lines () {


### PR DESCRIPTION
Modifying the options argument will cause failures when called with a frozen
object. Example:

```js
const options = Object.freeze({
  width: 30,
  break: true,
  eol: "<br>"
});

wordwrap.wrap("somelongstring", options);
```

By not modifying the argument, the above code will no longer cause failures

I have not added any tests to this PR yet, as I couldn't see any other tests that verify non-functional requirements. Should I add a test that verifies this?