### PR TITLE
Fix documentation: eol option is a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Old browser (adds `window.wordwrapjs`):
 | [options.width] | <code>number</code> | the max column width in characters (defaults to 30). |
 | [options.break] | <code>boolean</code> | if true, words exceeding the specified `width` will be forcefully broken |
 | [options.noTrim] | <code>boolean</code> | By default, each line output is trimmed. If `noTrim` is set, no line-trimming occurs - all whitespace from the input text is left in. |
-| [options.eol] | <code>boolean</code> | The end of line character to use. Defaults to `\n`. |
+| [options.eol] | <code>string</code> | The end of line character to use. Defaults to `\n`. |
 
 <a name="module_wordwrapjs--WordWrap.lines"></a>
 

--- a/index.mjs
+++ b/index.mjs
@@ -81,7 +81,7 @@ class WordWrap {
    * @param [options.width] {number} - the max column width in characters (defaults to 30).
    * @param [options.break] {boolean} - if true, words exceeding the specified `width` will be forcefully broken
    * @param [options.noTrim] {boolean} - By default, each line output is trimmed. If `noTrim` is set, no line-trimming occurs - all whitespace from the input text is left in.
-   * @param [options.eol] {boolean} - The end of line character to use. Defaults to `\n`.
+   * @param [options.eol] {string} - The end of line character to use. Defaults to `\n`.
    * @return {string}
    */
   static wrap (text, options) {


### PR DESCRIPTION
This PR fixes the invalid type for `eol` option in the documentation