### PR TITLE
Fix broken output for empty lines

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18,6 +18,8 @@ const re = {
   ansiEscapeSequence: /\u001b.*?m/g
 };
 
+const EMPTY_LINE = Symbol('emptyLine');
+
 /**
  * @alias module:wordwrapjs
  * @typicalname wordwrap
@@ -40,8 +42,11 @@ class Wordwrap {
     /* trim each line of the supplied text */
     return this._lines.map(trimLine, this)
 
-      /* split each line into an array of chunks, else mark it empty */
-      .map(line => line.match(re.chunk) || ['~~empty~~'])
+      /* split each line into an array of chunks, else mark it empty with a symbol */
+      .map(line => {
+        const chunks = line.match(re.chunk);
+        return chunks && chunks.length ? chunks : [EMPTY_LINE]
+      })
 
       /* optionally, break each word on the line into pieces */
       .map(lineWords => this.options.break
@@ -52,6 +57,11 @@ class Wordwrap {
 
       /* transforming the line of words to one or more new lines wrapped to size */
       .map(lineWords => {
+        /* if the line is the EMPTY_LINE symbol, preserve it */
+        if (lineWords.length === 1 && lineWords[0] === EMPTY_LINE) {
+          return lineWords
+        }
+
         return lineWords
           .reduce((lines, word) => {
             const currentLine = lines[lines.length - 1];
@@ -66,13 +76,14 @@ class Wordwrap {
       .flat()
 
       /* trim the wrapped lines */
-      .map(trimLine, this)
+      .map(line => (line === EMPTY_LINE ? '' : trimLine.call(this, line)))
 
-      /* filter out empty lines */
-      .filter(line => line.trim())
-
-      /* restore the user's original empty lines */
-      .map(line => line.replace('~~empty~~', ''))
+      /* filter out empty lines except those that were originally empty */
+      .filter((line, idx) => {
+        return line !== ''
+          || this._lines[idx] === ''
+          || (typeof this._lines[idx] !== 'undefined' && this._lines[idx].match(/^\s*$/))
+      })
   }
 
   wrap () {
@@ -136,6 +147,10 @@ function replaceAnsi (string) {
  * @private
  */
 function breakWord (word) {
+  if (word === EMPTY_LINE) {
+    return word
+  }
+
   if (replaceAnsi(word).length > this.options.width) {
     const letters = word.split('');
     let piece;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -16,6 +16,8 @@ const re = {
   ansiEscapeSequence: /\u001b.*?m/g
 };
 
+const EMPTY_LINE = Symbol('emptyLine');
+
 /**
  * @alias module:wordwrapjs
  * @typicalname wordwrap
@@ -38,8 +40,11 @@ class Wordwrap {
     /* trim each line of the supplied text */
     return this._lines.map(trimLine, this)
 
-      /* split each line into an array of chunks, else mark it empty */
-      .map(line => line.match(re.chunk) || ['~~empty~~'])
+      /* split each line into an array of chunks, else mark it empty with a symbol */
+      .map(line => {
+        const chunks = line.match(re.chunk);
+        return chunks && chunks.length ? chunks : [EMPTY_LINE]
+      })
 
       /* optionally, break each word on the line into pieces */
       .map(lineWords => this.options.break
@@ -50,6 +55,11 @@ class Wordwrap {
 
       /* transforming the line of words to one or more new lines wrapped to size */
       .map(lineWords => {
+        /* if the line is the EMPTY_LINE symbol, preserve it */
+        if (lineWords.length === 1 && lineWords[0] === EMPTY_LINE) {
+          return lineWords
+        }
+
         return lineWords
           .reduce((lines, word) => {
             const currentLine = lines[lines.length - 1];
@@ -64,13 +74,14 @@ class Wordwrap {
       .flat()
 
       /* trim the wrapped lines */
-      .map(trimLine, this)
+      .map(line => (line === EMPTY_LINE ? '' : trimLine.call(this, line)))
 
-      /* filter out empty lines */
-      .filter(line => line.trim())
-
-      /* restore the user's original empty lines */
-      .map(line => line.replace('~~empty~~', ''))
+      /* filter out empty lines except those that were originally empty */
+      .filter((line, idx) => {
+        return line !== ''
+          || this._lines[idx] === ''
+          || (typeof this._lines[idx] !== 'undefined' && this._lines[idx].match(/^\s*$/))
+      })
   }
 
   wrap () {
@@ -134,6 +145,10 @@ function replaceAnsi (string) {
  * @private
  */
 function breakWord (word) {
+  if (word === EMPTY_LINE) {
+    return word
+  }
+
   if (replaceAnsi(word).length > this.options.width) {
     const letters = word.split('');
     let piece;

--- a/index.js
+++ b/index.js
@@ -77,11 +77,11 @@ class Wordwrap {
       .map(line => (line === EMPTY_LINE ? '' : trimLine.call(this, line)))
 
       /* filter out empty lines except those that were originally empty */
-      .filter((line, idx) =>
-        line !== '' ||
-        this._lines[idx] === '' ||
-        this._lines[idx]?.match(/^\s*$/)
-      )
+      .filter((line, idx) => {
+        return line !== ''
+          || this._lines[idx] === ''
+          || (typeof this._lines[idx] !== 'undefined' && this._lines[idx].match(/^\s*$/))
+      })
   }
 
   wrap () {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ const re = {
   ansiEscapeSequence: /\u001b.*?m/g
 }
 
+const EMPTY_LINE = Symbol('emptyLine')
+
 /**
  * @alias module:wordwrapjs
  * @typicalname wordwrap
@@ -38,8 +40,11 @@ class Wordwrap {
     /* trim each line of the supplied text */
     return this._lines.map(trimLine, this)
 
-      /* split each line into an array of chunks, else mark it empty */
-      .map(line => line.match(re.chunk) || ['~~empty~~'])
+      /* split each line into an array of chunks, else mark it empty with a symbol */
+      .map(line => {
+        const chunks = line.match(re.chunk)
+        return chunks && chunks.length ? chunks : [EMPTY_LINE]
+      })
 
       /* optionally, break each word on the line into pieces */
       .map(lineWords => this.options.break
@@ -50,6 +55,11 @@ class Wordwrap {
 
       /* transforming the line of words to one or more new lines wrapped to size */
       .map(lineWords => {
+        /* if the line is the EMPTY_LINE symbol, preserve it */
+        if (lineWords.length === 1 && lineWords[0] === EMPTY_LINE) {
+          return lineWords
+        }
+
         return lineWords
           .reduce((lines, word) => {
             const currentLine = lines[lines.length - 1]
@@ -64,13 +74,14 @@ class Wordwrap {
       .flat()
 
       /* trim the wrapped lines */
-      .map(trimLine, this)
+      .map(line => (line === EMPTY_LINE ? '' : trimLine.call(this, line)))
 
-      /* filter out empty lines */
-      .filter(line => line.trim())
-
-      /* restore the user's original empty lines */
-      .map(line => line.replace('~~empty~~', ''))
+      /* filter out empty lines except those that were originally empty */
+      .filter((line, idx) =>
+        line !== '' ||
+        this._lines[idx] === '' ||
+        this._lines[idx]?.match(/^\s*$/)
+      )
   }
 
   wrap () {
@@ -134,6 +145,10 @@ function replaceAnsi (string) {
  * @private
  */
 function breakWord (word) {
+  if (word === EMPTY_LINE) {
+    return word
+  }
+
   if (replaceAnsi(word).length > this.options.width) {
     const letters = word.split('')
     let piece

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -101,6 +101,15 @@ test.set('wordwrap.lines(text): respect existing linebreaks', function () {
     wordwrap.lines('one\r\ntwo three four', { width: 8 }),
     ['one', 'two', 'three', 'four']
   )
+
+  a.deepEqual(wordwrap.lines('\n\n\n\n\n', { break: true, width: 5 }), [
+    '', // \n
+    '', // \n
+    '', // \n
+    '', // \n
+    '', // \n
+    ''
+  ])
 })
 
 test.set('wordwrap.lines(text): multilingual', function () {


### PR DESCRIPTION
Closes #11 

Happy to discuss the implementation. I think there's a couple ways to go about this fix, like wrapping each word/line in an object so you can attach metadata, but this way is a less invasive change.

Before this change, the test case would produce:

```
[
  '~~emp',
  'ty~~',
  '~~emp',
  'ty~~',
  '~~emp',
  'ty~~',
  '~~emp',
  'ty~~',
  '~~emp',
  'ty~~',
  '~~emp',
  'ty~~'
]
```

After this change, the test case will produce the expected:

```
[
  '',
  '',
  '',
  '',
  '',
  ''
]
```

FYI, the repo is not set up so that anyone else can run tests out of the box, due to the `@75lb/nature` package not being listed as a dev dependency as it really should be. I'd suggest listing it or switching to `node --test`; I hacked some code into the test file to run the suite before I thought to check what you're doing in the actions workflow and found the package name for the command.